### PR TITLE
make code size depend on type

### DIFF
--- a/qml/pass/CardFront.qml
+++ b/qml/pass/CardFront.qml
@@ -238,20 +238,20 @@ Rectangle {
 
       property double codeWidth: switch (passCard.pass.standard.barcodeFormat) {
                                     case "PKBarcodeFormatQR":
-                                        passCard.width * 0.6
+                                        passCard.width * 0.75
                                         break
                                     case "PKBarcodeFormatAztec":
-                                        passCard.width * 0.8
+                                        passCard.width * 0.9
                                         break
                                     default:
                                         passCard.width
                                 }
       property double codeHeight: switch (passCard.pass.standard.barcodeFormat) {
                                     case "PKBarcodeFormatQR":
-                                        passCard.width * 0.6
+                                        passCard.width * 0.75
                                         break
                                     case "PKBarcodeFormatAztec":
-                                        passCard.width * 0.8
+                                        passCard.width * 0.9
                                         break
                                     default:
                                         passCard.width * 0.4

--- a/qml/pass/CardFront.qml
+++ b/qml/pass/CardFront.qml
@@ -236,11 +236,26 @@ Rectangle {
    ListView {
       id: barcodeContent
 
-      property double codeWidth: passCard.width * 0.6
-      property double codeHeight: (passCard.pass.standard.barcodeFormat === "PKBarcodeFormatQR"
-                                   || passCard.pass.standard.barcodeFormat === "PKBarcodeFormatAztec")
-                                  ? passCard.width * 0.6
-                                  : passCard.width * 0.3
+      property double codeWidth: switch (passCard.pass.standard.barcodeFormat) {
+                                    case "PKBarcodeFormatQR":
+                                        passCard.width * 0.6
+                                        break
+                                    case "PKBarcodeFormatAztec":
+                                        passCard.width * 0.8
+                                        break
+                                    default:
+                                        passCard.width
+                                }
+      property double codeHeight: switch (passCard.pass.standard.barcodeFormat) {
+                                    case "PKBarcodeFormatQR":
+                                        passCard.width * 0.6
+                                        break
+                                    case "PKBarcodeFormatAztec":
+                                        passCard.width * 0.8
+                                        break
+                                    default:
+                                        passCard.width * 0.4
+                                }
 
       anchors.horizontalCenter: parent.horizontalCenter
       anchors.bottom: infoIconRect.top


### PR DESCRIPTION
This PR makes the visible size of code dependent on type the of code with some more size variations.

I found that especially barcodes are far too small. I had trouble to get them to read.

Also QR codes seem not to need as much space as Aztec codes which are larger, taken from my few codes.

So I thought we can have this a bit more flexible and dependent on the code type.