### PR TITLE
Adapt prebuild path

### DIFF
--- a/clickable.yaml
+++ b/clickable.yaml
@@ -10,4 +10,4 @@ libraries:
     builder: cmake
   zxing-cpp:
     builder: cmake
-    prebuild: "cd libs/zxing-cpp && git apply ../../zxing_patch.patch || exit 0"
+    prebuild: "git apply ../../../zxing_patch.patch || exit 0"

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 7
+clickable_minimum_required: 8
 builder: cmake
 kill: Passes
 framework: ubuntu-sdk-20.04


### PR DESCRIPTION
This PR may depend on #15 !

Not sure if that is related to the new version of clickable, but when building, I did ran into this error:

```
CMake Error in CMakeLists.txt:
  Imported target "ZXing::Core" includes non-existent path

    "/./include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

With changing this code, I did seem to fix it. 

Although it did work with that, after too much trying things, I now also seem to need a bump of quazip and zxing.